### PR TITLE
Replace request/request-promise-native with native fetch API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,6 @@
         "mongodb": "6.17.0",
         "morgan": "^1.10.0",
         "nconf": "^0.13.0",
-        "request": "^2.88.2",
-        "request-promise-native": "1.0.9",
         "sprintf-js": "^1.1.3",
         "xml2js": "^0.6.2",
         "xmlbuilder": "^15.1.1"
@@ -2734,11 +2732,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3795,39 +3788,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "license": "ISC",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
     "node_modules/request/node_modules/qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
@@ -4157,14 +4117,6 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/strftime": {
@@ -6676,11 +6628,6 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -7389,24 +7336,6 @@
         }
       }
     },
-    "request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "requires": {
-        "lodash": "^4.17.19"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "requires": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7618,11 +7547,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g=="
     },
     "strftime": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
     "mongodb": "6.17.0",
     "morgan": "^1.10.0",
     "nconf": "^0.13.0",
-    "request": "^2.88.2",
-    "request-promise-native": "1.0.9",
     "sprintf-js": "^1.1.3",
     "xml2js": "^0.6.2",
     "xmlbuilder": "^15.1.1"

--- a/services/notify-one.js
+++ b/services/notify-one.js
@@ -1,41 +1,49 @@
 const builder = require('xmlbuilder'),
     config = require('../config'),
     ErrorResponse = require('./error-response'),
-    request = require('request-promise-native'),
     { URL } = require('url');
 
 async function notifyOneRest(apiurl, resourceUrl) {
-    let res;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), config.requestTimeout);
 
     try {
-        res = await request({
-            method: 'POST',
-            uri: apiurl,
-            timeout: config.requestTimeout,
-            form: {
-                'url': resourceUrl
-            },
-            resolveWithFullResponse: true
-        });
-    } catch (err) {
-        if (!err.response) {
-            throw err;
-        }
+        const formData = new URLSearchParams();
+        formData.append('url', resourceUrl);
 
-        res = err.response;
-        if (res.statusCode >= 300 || res.statusCode < 400) {
-            if (res.headers.location) {
-                const location = new URL(res.headers.location, apiurl);
-                return notifyOneRest(location.toString(), resourceUrl);
+        const res = await fetch(apiurl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: formData,
+            signal: controller.signal,
+            redirect: 'manual'
+        });
+
+        clearTimeout(timeoutId);
+
+        // Handle redirects manually
+        if (res.status >= 300 && res.status < 400) {
+            const location = res.headers.get('location');
+            if (location) {
+                const redirectUrl = new URL(location, apiurl);
+                return notifyOneRest(redirectUrl.toString(), resourceUrl);
             }
         }
-    }
 
-    if (res.statusCode < 200 || res.statusCode > 299) {
-        throw new ErrorResponse('Notification Failed');
-    }
+        if (res.status < 200 || res.status > 299) {
+            throw new ErrorResponse('Notification Failed');
+        }
 
-    return true;
+        return true;
+    } catch (err) {
+        clearTimeout(timeoutId);
+        if (err.name === 'AbortError') {
+            throw new ErrorResponse('Notification Failed - Timeout');
+        }
+        throw err;
+    }
 }
 
 async function notifyOneRpc(notifyProcedure, apiurl, resourceUrl) {
@@ -50,22 +58,33 @@ async function notifyOneRpc(notifyProcedure, apiurl, resourceUrl) {
         }
     }).end({ pretty: true });
 
-    let res = await request({
-        method: 'POST',
-        uri: apiurl,
-        timeout: 4000,
-        body: xmldoc,
-        resolveWithFullResponse: true,
-        headers: {
-            'content-type': 'text/xml'
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 4000);
+
+    try {
+        const res = await fetch(apiurl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'text/xml'
+            },
+            body: xmldoc,
+            signal: controller.signal
+        });
+
+        clearTimeout(timeoutId);
+
+        if (res.status < 200 || res.status > 299) {
+            throw new ErrorResponse('Notification Failed');
         }
-    });
 
-    if (res.statusCode < 200 || res.statusCode > 299) {
-        throw new ErrorResponse('Notification Failed');
+        return true;
+    } catch (err) {
+        clearTimeout(timeoutId);
+        if (err.name === 'AbortError') {
+            throw new ErrorResponse('Notification Failed - Timeout');
+        }
+        throw err;
     }
-
-    return true;
 }
 
 function notifyOne(notifyProcedure, apiurl, protocol, resourceUrl) {


### PR DESCRIPTION
- Remove deprecated request and request-promise-native dependencies
- Update all HTTP client services to use Node.js native fetch API
- Implement proper timeout handling with AbortController
- Maintain existing error handling and redirect behavior
- Convert form data and XML request handling to fetch patterns

Services updated:
- services/notify-one.js: REST and RPC notification endpoints
- services/ping.js: Resource change detection
- services/notify-one-challenge.js: Challenge verification
- services/please-notify.js: Resource URL validation

Benefits:
- Remove security vulnerabilities from deprecated packages
- Use modern native Node.js APIs
- Reduce bundle size and dependency count
- Better performance with native implementation

🤖 Generated with [Claude Code](https://claude.ai/code)