### PR TITLE
Stabilize 2.2.x branch with dependency updates and code quality fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,7 @@ This is an rssCloud Server v2 implementation in Node.js - a notification protoco
 
 - `npm test` - Run Mocha test suite (called by test-api)
 - `npm run test-api` - Run full API tests using Docker containers (MacOS tested)
-- `npm run jshint` - Run JSHint linter
-- `npm run eslint` - Run ESLint with auto-fix on controllers/, services/, test/
+- `npm run lint` - Run ESLint with auto-fix on controllers/, services/, test/
 
 ### Data Management
 

--- a/app.js
+++ b/app.js
@@ -18,8 +18,7 @@ console.log(`${config.appName} ${config.appVersion}`);
 // TODO: Every 24 hours run removeExpiredSubscriptions(data);
 
 morgan.format('mydate', () => {
-    const df = require('dateformat');
-    return df(new Date(), 'HH:MM:ss.l');
+    return new Date().toLocaleTimeString('en-US', { hour12: false, fractionalSecondDigits: 3 }).replace(/:/g, ':');
 });
 
 // Initialize dayjs at startup

--- a/client.js
+++ b/client.js
@@ -31,8 +31,7 @@ nconf
 console.log(`${nconf.get('APP_NAME')} ${nconf.get('APP_VERSION')}`);
 
 morgan.format('mydate', () => {
-    const df = require('dateformat');
-    return df(new Date(), 'HH:MM:ss.l');
+    return new Date().toLocaleTimeString('en-US', { hour12: false, fractionalSecondDigits: 3 }).replace(/:/g, ':');
 });
 
 app = express();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,12 @@ module.exports = [
                 module: 'readonly',
                 require: 'readonly',
                 exports: 'readonly',
+                // Node.js built-in globals
+                fetch: 'readonly',
+                AbortController: 'readonly',
+                setTimeout: 'readonly',
+                clearTimeout: 'readonly',
+                URLSearchParams: 'readonly',
                 // Mocha globals
                 describe: 'readonly',
                 it: 'readonly',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rsscloud-server",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rsscloud-server",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^2.2.0",
@@ -15,7 +15,7 @@
         "davexmlrpc": "^0.4.26",
         "dayjs": "^1.11.13",
         "dotenv": "^16.5.0",
-        "express": "^4.17.1",
+        "express": "^4.21.2",
         "express-handlebars": "^5.3.3",
         "express-ws": "^5.0.2",
         "markdown-it": "^14.1.0",
@@ -34,10 +34,10 @@
         "eslint": "^9.29.0",
         "eslint-config-crockford": "^2.0.0",
         "https": "^1.0.0",
-        "mocha": "^11.7.0",
+        "mocha": "^11.7.1",
         "mocha-multi": "^1.1.7",
         "nodemon": "3.1.10",
-        "prettier": "^3.4.2",
+        "prettier": "^3.6.1",
         "supertest": "^7.1.1"
       },
       "engines": {
@@ -2927,9 +2927,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.0.tgz",
-      "integrity": "sha512-bXfLy/mI8n4QICg+pWj1G8VduX5vC0SHRwFpiR5/Fxc8S2G906pSfkyMmHVsdJNQJQNh3LE67koad9GzEvkV6g==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
+      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3637,9 +3637,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
-      "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.1.tgz",
+      "integrity": "sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6756,9 +6756,9 @@
       "dev": true
     },
     "mocha": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.0.tgz",
-      "integrity": "sha512-bXfLy/mI8n4QICg+pWj1G8VduX5vC0SHRwFpiR5/Fxc8S2G906pSfkyMmHVsdJNQJQNh3LE67koad9GzEvkV6g==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
+      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
       "dev": true,
       "requires": {
         "browser-stdout": "^1.3.1",
@@ -7222,9 +7222,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
-      "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.1.tgz",
+      "integrity": "sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==",
       "dev": true
     },
     "proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsscloud-server",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "description": "An rssCloud Server",
   "main": "app.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "cors": "^2.8.5",
     "davexmlrpc": "^0.4.26",
     "dotenv": "^16.5.0",
-    "express": "^4.17.1",
+    "express": "^4.21.2",
     "express-handlebars": "^5.3.3",
     "express-ws": "^5.0.2",
     "markdown-it": "^14.1.0",
@@ -47,10 +47,10 @@
     "eslint": "^9.29.0",
     "eslint-config-crockford": "^2.0.0",
     "https": "^1.0.0",
-    "mocha": "^11.7.0",
+    "mocha": "^11.7.1",
     "mocha-multi": "^1.1.7",
     "nodemon": "3.1.10",
-    "prettier": "^3.4.2",
+    "prettier": "^3.6.1",
     "supertest": "^7.1.1"
   }
 }

--- a/services/dayjs-wrapper.js
+++ b/services/dayjs-wrapper.js
@@ -7,7 +7,7 @@ async function getDayjs() {
         const advancedFormat = await import('dayjs/plugin/advancedFormat.js');
         const duration = await import('dayjs/plugin/duration.js');
         const customParseFormat = await import('dayjs/plugin/customParseFormat.js');
-        
+
         dayjs = dayjsModule.default;
         dayjs.extend(utc.default);
         dayjs.extend(advancedFormat.default);


### PR DESCRIPTION
- Update dependencies: express 4.17.1→4.21.2, mocha 11.7.0→11.7.1, prettier 3.4.2→3.6.1
- Fix ESLint configuration by adding missing Node.js globals (fetch, AbortController, etc.)
- Remove dateformat dependency, replace with native toLocaleTimeString
- Update package version to 2.2.0
- Update CLAUDE.md documentation for lint command

🤖 Generated with [Claude Code](https://claude.ai/code)