### PR TITLE
Implement log cleanup with 2-hour retention and fix subscription cleanup

### DIFF
--- a/config.js
+++ b/config.js
@@ -21,7 +21,8 @@ nconf
         'MAX_RESOURCE_SIZE': 256000,
         'CT_SECS_RESOURCE_EXPIRE': 90000,
         'MIN_SECS_BETWEEN_PINGS': 0,
-        'REQUEST_TIMEOUT': 4000
+        'REQUEST_TIMEOUT': 4000,
+        'LOG_RETENTION_HOURS': 2
     });
 
 module.exports = {
@@ -34,5 +35,6 @@ module.exports = {
     maxResourceSize: nconf.get('MAX_RESOURCE_SIZE'),
     ctSecsResourceExpire: nconf.get('CT_SECS_RESOURCE_EXPIRE'),
     minSecsBetweenPings: nconf.get('MIN_SECS_BETWEEN_PINGS'),
-    requestTimeout: nconf.get('REQUEST_TIMEOUT')
+    requestTimeout: nconf.get('REQUEST_TIMEOUT'),
+    logRetentionHours: nconf.get('LOG_RETENTION_HOURS')
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,8 @@ module.exports = [
                 AbortController: 'readonly',
                 setTimeout: 'readonly',
                 clearTimeout: 'readonly',
+                setInterval: 'readonly',
+                clearInterval: 'readonly',
                 URLSearchParams: 'readonly',
                 // Mocha globals
                 describe: 'readonly',

--- a/services/log-cleanup.js
+++ b/services/log-cleanup.js
@@ -1,0 +1,59 @@
+const getDatabase = require('./mongodb');
+const config = require('../config');
+
+/**
+ * Sets up TTL (Time To Live) index on the events collection
+ * This will automatically expire log entries after the configured retention period
+ */
+async function setupLogRetention() {
+    try {
+        const db = await getDatabase();
+        const collection = db.collection('events');
+
+        const retentionSeconds = config.logRetentionHours * 3600;
+
+        // Create TTL index on the when field (log timestamp)
+        // MongoDB will automatically delete documents when 'when' is older than retentionSeconds
+        await collection.createIndex(
+            { when: 1 },
+            {
+                expireAfterSeconds: retentionSeconds,
+                name: 'log_retention_ttl'
+            }
+        );
+
+        console.log(`Log retention TTL index created: ${config.logRetentionHours} hours (${retentionSeconds} seconds)`);
+    } catch (error) {
+        console.error('Error setting up log retention TTL index:', error);
+        throw error;
+    }
+}
+
+/**
+ * Manually removes expired log entries (alternative to TTL)
+ * This is a fallback method if TTL index setup fails
+ */
+async function removeExpiredLogs() {
+    try {
+        const db = await getDatabase();
+        const collection = db.collection('events');
+
+        const cutoffDate = new Date();
+        cutoffDate.setHours(cutoffDate.getHours() - config.logRetentionHours);
+
+        const result = await collection.deleteMany({
+            when: { $lt: cutoffDate }
+        });
+
+        console.log(`Removed ${result.deletedCount} expired log entries older than ${cutoffDate.toISOString()}`);
+        return result.deletedCount;
+    } catch (error) {
+        console.error('Error removing expired logs:', error);
+        throw error;
+    }
+}
+
+module.exports = {
+    setupLogRetention,
+    removeExpiredLogs
+};


### PR DESCRIPTION
- Add LOG_RETENTION_HOURS config setting (default: 2 hours)
- Create log-cleanup service with MongoDB TTL index for automatic log expiration
- Rewrite removeExpiredSubscriptions to work with MongoDB schema
- Enable 24-hour scheduled cleanup for expired/errored subscriptions
- Add setInterval/clearInterval to ESLint globals
- Setup TTL index and cleanup scheduling on server startup

🤖 Generated with [Claude Code](https://claude.ai/code)