### PR TITLE
Fix getDatabase usage in log-cleanup and remove-expired-subscriptions

### DIFF
--- a/services/remove-expired-subscriptions.js
+++ b/services/remove-expired-subscriptions.js
@@ -1,4 +1,4 @@
-const getDatabase = require('./mongodb');
+const mongodb = require('./mongodb');
 const getDayjs = require('./dayjs-wrapper');
 const config = require('../config');
 
@@ -8,7 +8,7 @@ const config = require('../config');
  */
 async function removeExpiredSubscriptions() {
     try {
-        const db = await getDatabase();
+        const db = mongodb.get('rsscloud');
         const dayjs = await getDayjs();
         const collection = db.collection('subscriptions');
 


### PR DESCRIPTION
- Replace getDatabase import with mongodb module
- Use mongodb.get('rsscloud') instead of getDatabase()
- Fix TTL index to use 'time' field instead of 'when' field

🤖 Generated with [Claude Code](https://claude.ai/code)